### PR TITLE
Cscarvo 407 toimipaikka oidilla

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ ansible/aipal_vagrant/salasanat/
 /e2e/screenshot-*.png
 .idea
 *.iml
+hs_err_pid*.log
+replay_pid*.log

--- a/aipal/resources/migrations/20190426161300-toimipaikka-siivous.down.sql
+++ b/aipal/resources/migrations/20190426161300-toimipaikka-siivous.down.sql
@@ -1,3 +1,6 @@
+-- Toimipaikat pitää nollata koska ei voida olla varmoja onko uudelle primary keylle tullut duplikaatteja
+truncate toimipaikka;
+alter table toimipaikka add unique (toimipaikkakoodi);
 alter table kysely
     add column toimipaikka character varying(7),
     add constraint kysely_toimipaikka_fk foreign key (toimipaikka) references toimipaikka(toimipaikkakoodi);
@@ -8,8 +11,8 @@ alter table kyselypohja
     add column toimipaikka character varying(7),
     add constraint kyselypohja_toimipaikka_fk foreign key (toimipaikka) references toimipaikka(toimipaikkakoodi);
 alter table vastaajatunnus
-    add column toimipaikka character varying(7),
-    add constraint vastaajatunnus_valmistavan_koulutuksen_toimipaikka_fkey foreign key (toimipaikka) references toimipaikka(toimipaikkakoodi);
+    add column valmistavan_koulutuksen_toimipaikka character varying(10),
+    add constraint vastaajatunnus_valmistavan_koulutuksen_toimipaikka_fkey foreign key (valmistavan_koulutuksen_toimipaikka) references toimipaikka(toimipaikkakoodi);
 
 drop view kysely_organisaatio_view;
 create view kysely_organisaatio_view
@@ -35,7 +38,7 @@ UNION ALL
     k.toimipaikka
    FROM kysely k
   WHERE k.koulutustoimija IS NOT NULL;
-
+grant select on kysely_organisaatio_view to PUBLIC;
 
 drop view kysymysryhma_organisaatio_view;
 create view kysymysryhma_organisaatio_view
@@ -64,7 +67,7 @@ UNION ALL
     kr.valtakunnallinen
    FROM kysymysryhma kr
   WHERE kr.koulutustoimija IS NOT NULL OR kr.valtakunnallinen = true;
-
+grant select on kysymysryhma_organisaatio_view to PUBLIC;
 
 drop view kyselypohja_organisaatio_view;
 create view kyselypohja_organisaatio_view
@@ -93,6 +96,7 @@ UNION ALL
     kp.valtakunnallinen
    FROM kyselypohja kp
   WHERE kp.koulutustoimija IS NOT NULL OR kp.valtakunnallinen = true;
+grant select on kyselypohja_organisaatio_view to PUBLIC;
 
 create view kayttotilasto_view
 AS
@@ -115,13 +119,11 @@ AS
      JOIN kyselykerta kt ON kt.kyselykertaid = vt.kyselykertaid
      JOIN kysely k ON k.kyselyid = kt.kyselyid
      JOIN kysely_organisaatio_view kov ON kov.kyselyid = kt.kyselyid
-  GROUP BY kov.koulutustoimija, kov.oppilaitos, kov.toimipaikka, vt.tutkintotunn
-us, kt.kyselyid, k.nimi_fi
+  GROUP BY kov.koulutustoimija, kov.oppilaitos, kov.toimipaikka, vt.tutkintotunnus, kt.kyselyid, k.nimi_fi
   ORDER BY kov.koulutustoimija, kov.oppilaitos, vt.tutkintotunnus, kt.kyselyid;
+grant select on kayttotilasto_view to PUBLIC;
 
-
--- Toimipaikat pitää nollata koska ei voida olla varmoja onko uudelle primary keylle tullut duplikaatteja
-truncate toimipaikka;
+-- Haetaan kaikki organisaatiot uudestaan
 truncate organisaatiopalvelu_log;
 -- Tämän pk vaihdon voi tehdä vasta kun duplikaattitoimipaikkakoodit on siivottu
 alter table toimipaikka drop constraint toimipaikka_pkey;

--- a/aipal/resources/migrations/20190426161300-toimipaikka-siivous.down.sql
+++ b/aipal/resources/migrations/20190426161300-toimipaikka-siivous.down.sql
@@ -1,0 +1,128 @@
+alter table kysely
+    add column toimipaikka character varying(7),
+    add constraint kysely_toimipaikka_fk foreign key (toimipaikka) references toimipaikka(toimipaikkakoodi);
+alter table kysymysryhma
+    add column toimipaikka character varying(7),
+    add constraint kysymysryhma_toimipaikka_fk foreign key (toimipaikka) references toimipaikka(toimipaikkakoodi);
+alter table kyselypohja
+    add column toimipaikka character varying(7),
+    add constraint kyselypohja_toimipaikka_fk foreign key (toimipaikka) references toimipaikka(toimipaikkakoodi);
+alter table vastaajatunnus
+    add column toimipaikka character varying(7),
+    add constraint vastaajatunnus_valmistavan_koulutuksen_toimipaikka_fkey foreign key (toimipaikka) references toimipaikka(toimipaikkakoodi);
+
+drop view kysely_organisaatio_view;
+create view kysely_organisaatio_view
+AS
+ SELECT k.kyselyid,
+    o.koulutustoimija,
+    k.oppilaitos,
+    k.toimipaikka
+   FROM kysely k
+     JOIN toimipaikka t ON t.toimipaikkakoodi::text = k.toimipaikka::text
+     JOIN oppilaitos o ON o.oppilaitoskoodi::text = t.oppilaitos::text
+UNION ALL
+ SELECT k.kyselyid,
+    o.koulutustoimija,
+    k.oppilaitos,
+    k.toimipaikka
+   FROM kysely k
+     JOIN oppilaitos o ON o.oppilaitoskoodi::text = k.oppilaitos::text
+UNION ALL
+ SELECT k.kyselyid,
+    k.koulutustoimija,
+    k.oppilaitos,
+    k.toimipaikka
+   FROM kysely k
+  WHERE k.koulutustoimija IS NOT NULL;
+
+
+drop view kysymysryhma_organisaatio_view;
+create view kysymysryhma_organisaatio_view
+AS
+ SELECT kr.kysymysryhmaid,
+    o.koulutustoimija,
+    kr.oppilaitos,
+    kr.toimipaikka,
+    kr.valtakunnallinen
+   FROM kysymysryhma kr
+     JOIN toimipaikka t ON t.toimipaikkakoodi::text = kr.toimipaikka::text
+     JOIN oppilaitos o ON o.oppilaitoskoodi::text = t.oppilaitos::text
+UNION ALL
+ SELECT kr.kysymysryhmaid,
+    o.koulutustoimija,
+    kr.oppilaitos,
+    kr.toimipaikka,
+    kr.valtakunnallinen
+   FROM kysymysryhma kr
+     JOIN oppilaitos o ON o.oppilaitoskoodi::text = kr.oppilaitos::text
+UNION ALL
+ SELECT kr.kysymysryhmaid,
+    kr.koulutustoimija,
+    kr.oppilaitos,
+    kr.toimipaikka,
+    kr.valtakunnallinen
+   FROM kysymysryhma kr
+  WHERE kr.koulutustoimija IS NOT NULL OR kr.valtakunnallinen = true;
+
+
+drop view kyselypohja_organisaatio_view;
+create view kyselypohja_organisaatio_view
+AS
+ SELECT kp.kyselypohjaid,
+    o.koulutustoimija,
+    kp.oppilaitos,
+    kp.toimipaikka,
+    kp.valtakunnallinen
+   FROM kyselypohja kp
+     JOIN toimipaikka t ON t.toimipaikkakoodi::text = kp.toimipaikka::text
+     JOIN oppilaitos o ON o.oppilaitoskoodi::text = t.oppilaitos::text
+UNION ALL
+ SELECT kp.kyselypohjaid,
+    o.koulutustoimija,
+    kp.oppilaitos,
+    kp.toimipaikka,
+    kp.valtakunnallinen
+   FROM kyselypohja kp
+     JOIN oppilaitos o ON o.oppilaitoskoodi::text = kp.oppilaitos::text
+UNION ALL
+ SELECT kp.kyselypohjaid,
+    kp.koulutustoimija,
+    kp.oppilaitos,
+    kp.toimipaikka,
+    kp.valtakunnallinen
+   FROM kyselypohja kp
+  WHERE kp.koulutustoimija IS NOT NULL OR kp.valtakunnallinen = true;
+
+create view kayttotilasto_view
+AS
+ SELECT vt.tutkintotunnus,
+    sum(
+        CASE
+            WHEN v.vastannut THEN vt.vastaajien_lkm
+            ELSE 0
+        END) AS vastauksia,
+    sum(vt.vastaajien_lkm) AS tunnuksia,
+    min(v.muutettuaika) AS vastaus_alkupvm,
+    max(v.muutettuaika) AS vastaus_loppupvm,
+    kt.kyselyid,
+    kov.koulutustoimija,
+    kov.oppilaitos,
+    kov.toimipaikka,
+    k.nimi_fi
+   FROM vastaajatunnus vt
+     LEFT JOIN vastaaja v ON v.vastaajatunnusid = vt.vastaajatunnusid
+     JOIN kyselykerta kt ON kt.kyselykertaid = vt.kyselykertaid
+     JOIN kysely k ON k.kyselyid = kt.kyselyid
+     JOIN kysely_organisaatio_view kov ON kov.kyselyid = kt.kyselyid
+  GROUP BY kov.koulutustoimija, kov.oppilaitos, kov.toimipaikka, vt.tutkintotunn
+us, kt.kyselyid, k.nimi_fi
+  ORDER BY kov.koulutustoimija, kov.oppilaitos, vt.tutkintotunnus, kt.kyselyid;
+
+
+-- Toimipaikat pitää nollata koska ei voida olla varmoja onko uudelle primary keylle tullut duplikaatteja
+truncate toimipaikka;
+truncate organisaatiopalvelu_log;
+-- Tämän pk vaihdon voi tehdä vasta kun duplikaattitoimipaikkakoodit on siivottu
+alter table toimipaikka drop constraint toimipaikka_pkey;
+alter table toimipaikka add primary key (toimipaikkakoodi);

--- a/aipal/resources/migrations/20190426161300-toimipaikka-siivous.sql
+++ b/aipal/resources/migrations/20190426161300-toimipaikka-siivous.sql
@@ -1,0 +1,72 @@
+-- Vaihtaa toimipaikan primary keyksi toimipaikkakoodi => oid ja siivoaa käyttämättömiä viittauksia toimipaikkaan.
+
+alter table kysely drop constraint kysely_toimipaikka_fk;
+alter table kysymysryhma drop constraint kysymysryhma_toimipaikka_fk;
+alter table kyselypohja drop constraint kyselypohja_toimipaikka_fk;
+alter table vastaajatunnus drop constraint vastaajatunnus_valmistavan_koulutuksen_toimipaikka_fkey;
+
+alter table toimipaikka drop constraint toimipaikka_pkey;
+alter table toimipaikka add primary key (oid);
+
+-- Poistetaan turha näkymä
+drop view kayttotilasto_view;
+
+-- kysely (toimipaikka) sarakkeen viittausten siivous ja poisto
+drop view kysely_organisaatio_view;
+create view kysely_organisaatio_view
+AS
+ SELECT k.kyselyid,
+    o.koulutustoimija,
+    k.oppilaitos
+   FROM kysely k
+     JOIN oppilaitos o ON o.oppilaitoskoodi::text = k.oppilaitos::text
+UNION ALL
+ SELECT k.kyselyid,
+    k.koulutustoimija,
+    k.oppilaitos
+   FROM kysely k
+  WHERE k.koulutustoimija IS NOT NULL;
+alter table kysely drop column toimipaikka;
+
+-- kysymysryhma (toimipaikka) sarakkeen viittausten siivous ja poisto
+drop view kysymysryhma_organisaatio_view;
+create view kysymysryhma_organisaatio_view
+AS
+ SELECT kr.kysymysryhmaid,
+    o.koulutustoimija,
+    kr.oppilaitos,
+    kr.valtakunnallinen
+   FROM kysymysryhma kr
+     JOIN oppilaitos o ON o.oppilaitoskoodi::text = kr.oppilaitos::text
+UNION ALL
+ SELECT kr.kysymysryhmaid,
+    kr.koulutustoimija,
+    kr.oppilaitos,
+    kr.valtakunnallinen
+   FROM kysymysryhma kr
+  WHERE kr.koulutustoimija IS NOT NULL OR kr.valtakunnallinen = true;
+alter table kysymysryhma drop column toimipaikka;
+
+-- kyselypohja (toimipaikka) sarakkeen viittausten siivous ja poisto
+drop view kyselypohja_organisaatio_view;
+create view kyselypohja_organisaatio_view
+AS
+ SELECT kp.kyselypohjaid,
+    o.koulutustoimija,
+    kp.oppilaitos,
+    kp.valtakunnallinen
+   FROM kyselypohja kp
+     JOIN oppilaitos o ON o.oppilaitoskoodi::text = kp.oppilaitos::text
+UNION ALL
+ SELECT kp.kyselypohjaid,
+    kp.koulutustoimija,
+    kp.oppilaitos,
+    kp.valtakunnallinen
+   FROM kyselypohja kp
+  WHERE kp.koulutustoimija IS NOT NULL OR kp.valtakunnallinen = true;
+alter table kyselypohja drop column toimipaikka;
+
+-- vastaajatunnus (valmistavan_koulutuksen_toimipaikka) rajakkeen tietojen talteenotto ja poisto
+update vastaajatunnus set taustatiedot = '{}' where taustatiedot is null;
+update vastaajatunnus set taustatiedot = taustatiedot::jsonb || ('{"toimipaikka":' || valmistavan_koulutuksen_toimipaikka || '}')::jsonb where valmistavan_koulutuksen_toimipaikka is not null;
+alter table vastaajatunnus drop column valmistavan_koulutuksen_toimipaikka;

--- a/aipal/resources/migrations/20190426161300-toimipaikka-siivous.up.sql
+++ b/aipal/resources/migrations/20190426161300-toimipaikka-siivous.up.sql
@@ -23,6 +23,7 @@ UNION ALL
     k.oppilaitos
    FROM kysely k
   WHERE k.koulutustoimija IS NOT NULL;
+grant select on kysely_organisaatio_view to PUBLIC;
 alter table kysely drop column toimipaikka;
 
 -- kysymysryhma (toimipaikka) sarakkeen viittausten siivous ja poisto
@@ -42,6 +43,7 @@ UNION ALL
     kr.valtakunnallinen
    FROM kysymysryhma kr
   WHERE kr.koulutustoimija IS NOT NULL OR kr.valtakunnallinen = true;
+grant select on kysymysryhma_organisaatio_view to PUBLIC;
 alter table kysymysryhma drop column toimipaikka;
 
 -- kyselypohja (toimipaikka) sarakkeen viittausten siivous ja poisto
@@ -61,6 +63,7 @@ UNION ALL
     kp.valtakunnallinen
    FROM kyselypohja kp
   WHERE kp.koulutustoimija IS NOT NULL OR kp.valtakunnallinen = true;
+grant select on kyselypohja_organisaatio_view to PUBLIC;
 alter table kyselypohja drop column toimipaikka;
 
 -- vastaajatunnus (valmistavan_koulutuksen_toimipaikka) rajakkeen tietojen talteenotto ja poisto

--- a/aipal/resources/migrations/20190426161300-toimipaikka-siivous.up.sql
+++ b/aipal/resources/migrations/20190426161300-toimipaikka-siivous.up.sql
@@ -5,9 +5,6 @@ alter table kysymysryhma drop constraint kysymysryhma_toimipaikka_fk;
 alter table kyselypohja drop constraint kyselypohja_toimipaikka_fk;
 alter table vastaajatunnus drop constraint vastaajatunnus_valmistavan_koulutuksen_toimipaikka_fkey;
 
-alter table toimipaikka drop constraint toimipaikka_pkey;
-alter table toimipaikka add primary key (oid);
-
 -- Poistetaan turha näkymä
 drop view kayttotilasto_view;
 
@@ -70,3 +67,12 @@ alter table kyselypohja drop column toimipaikka;
 update vastaajatunnus set taustatiedot = '{}' where taustatiedot is null;
 update vastaajatunnus set taustatiedot = taustatiedot::jsonb || ('{"toimipaikka":' || valmistavan_koulutuksen_toimipaikka || '}')::jsonb where valmistavan_koulutuksen_toimipaikka is not null;
 alter table vastaajatunnus drop column valmistavan_koulutuksen_toimipaikka;
+
+
+-- Tyhjennä toimipaikat
+truncate toimipaikka;
+-- Tyhjennä aikaleima jolloin kaikki organisaatiot haetaan uudestaan
+truncate organisaatiopalvelu_log;
+-- Tämän pk vaihdon voi tehdä vasta kun duplikaattioidit on siivottu
+alter table toimipaikka drop constraint toimipaikka_pkey;
+alter table toimipaikka add primary key (oid);

--- a/aipal/resources/migrations/20190426161300-toimipaikka-siivous.up.sql
+++ b/aipal/resources/migrations/20190426161300-toimipaikka-siivous.up.sql
@@ -65,7 +65,7 @@ alter table kyselypohja drop column toimipaikka;
 
 -- vastaajatunnus (valmistavan_koulutuksen_toimipaikka) rajakkeen tietojen talteenotto ja poisto
 update vastaajatunnus set taustatiedot = '{}' where taustatiedot is null;
-update vastaajatunnus set taustatiedot = taustatiedot::jsonb || ('{"toimipaikka":' || valmistavan_koulutuksen_toimipaikka || '}')::jsonb where valmistavan_koulutuksen_toimipaikka is not null;
+update vastaajatunnus set taustatiedot = taustatiedot::jsonb || ('{"toimipaikka":"' || valmistavan_koulutuksen_toimipaikka || '"}')::jsonb where valmistavan_koulutuksen_toimipaikka is not null;
 alter table vastaajatunnus drop column valmistavan_koulutuksen_toimipaikka;
 
 

--- a/aipal/src/clj/aipal/arkisto/toimipaikka.clj
+++ b/aipal/src/clj/aipal/arkisto/toimipaikka.clj
@@ -23,10 +23,10 @@
     (sql/values tiedot)))
 
 (defn ^:integration-api paivita!
-  [toimipaikkakoodi tiedot]
+  [oid tiedot]
   (sql/update taulut/toimipaikka
     (sql/set-fields tiedot)
-    (sql/where {:toimipaikkakoodi toimipaikkakoodi})))
+    (sql/where {:oid oid})))
 
 (defn ^:integration-api aseta-kaikki-vanhentuneiksi!
   []

--- a/aipal/src/clj/aipal/infra/eraajo.clj
+++ b/aipal/src/clj/aipal/infra/eraajo.clj
@@ -51,6 +51,13 @@
                             (t/with-identity "daily3")
                             (t/start-now)
                             (t/with-schedule (ajastus asetukset :organisaatiopalvelu)))
+        org-job2 (j/build
+                 (j/of-type PaivitaOrganisaatiotJob)
+                 (j/with-identity "paivita-organisaatiot2")
+                 (j/using-job-data {"asetukset" (:organisaatiopalvelu asetukset)}))
+        org-trigger-once (t/build
+                          (t/with-identity "startup")
+                          (t/start-now))
         koul-job (j/build
                    (j/of-type PaivitaKoulutustoimijoidenTutkinnotJob)
                    (j/with-identity "paivita-koulutustoimijoiden-tutkinnot"))
@@ -74,6 +81,7 @@
                             (t/start-now)
                             (t/with-schedule (ajastus asetukset :tutkinnot)))]
     (qs/schedule @ajastin org-job org-trigger-daily)
+    (qs/schedule @ajastin org-job2 org-trigger-once)
     (qs/schedule @ajastin koul-job koul-trigger-daily)
     (qs/schedule @ajastin raportointi-job raportointi-trigger)
     (qs/schedule @ajastin tutkinnot-job tutkinnot-trigger)))

--- a/aipal/src/clj/aipal/integraatio/organisaatiopalvelu.clj
+++ b/aipal/src/clj/aipal/integraatio/organisaatiopalvelu.clj
@@ -45,7 +45,8 @@
 
 ; Haetaan minuutin tarkkuudella niin voidaan tarvittaessa hakea useasti päivässä
 (defn hae-muuttuneet [url viimeisin-paivitys]
-  (let [org-aikaleima (f/unparse organisaatiopalvelu-formatter (f/parse viimeisin-paivitys))]
+;  Substracting one minute to be sure no data is omitted
+  (let [org-aikaleima (f/unparse organisaatiopalvelu-formatter (time/minus viimeisin-paivitys (time/minutes 1)))]
     (log/info "Haetaan muuttuneet organisaatiot organisaatiopalvelusta" url "aikaleimalla" org-aikaleima)
     (map (comp lisaa-oppilaitostyyppi halutut-kentat)
          (get-json-from-url (str url "v4/muutetut") {:query-params {"lastModifiedSince" org-aikaleima}}))))

--- a/aipal/src/clj/aipal/integraatio/organisaatiopalvelu.clj
+++ b/aipal/src/clj/aipal/integraatio/organisaatiopalvelu.clj
@@ -262,7 +262,7 @@
     (paivita-toimipaikat! toimipaikkakoodit)))
 
 (defn paivita-erassa [oids paivitys-funktio url]
-  (let [oid-erat (partition 200 oids)]
+  (let [oid-erat (partition-all 200 oids)]
     (db/transaction
      (run! (comp paivitys-funktio #(hae-era % url)) oid-erat))))
 

--- a/aipal/src/clj/aipal/integraatio/organisaatiopalvelu.clj
+++ b/aipal/src/clj/aipal/integraatio/organisaatiopalvelu.clj
@@ -256,6 +256,7 @@
         koulutustoimijakoodit (:koulutustoimija koodit-tyypeittain)
         oppilaitoskoodit (:oppilaitos koodit-tyypeittain)
         toimipaikkakoodit (:toimipaikka koodit-tyypeittain)]
+    (log/info "Haettu muuttuneet organisaatiot," (count koodit) "kpl")
     (paivita-koulutustoimijat! koulutustoimijakoodit)
     (paivita-oppilaitokset! oppilaitoskoodit)
     (paivita-toimipaikat! toimipaikkakoodit)))
@@ -266,6 +267,7 @@
      (run! (comp paivitys-funktio #(hae-era % url)) oid-erat))))
 
 (defn hae-ja-paivita-kaikki [url]
+  (log/info "Haetaan kaikki koulutustoimijat, oppilaitokset ja toimipisteet organisaatiopalvelusta")
   (let [koulutustoimija-oidit (hae-oidit-tyypilla url "KOULUTUSTOIMIJA")
         oppilaitos-oidit (hae-oidit-tyypilla url "OPPILAITOS")
         toimipiste-oidit (hae-oidit-tyypilla url "TOIMIPISTE")]
@@ -282,9 +284,7 @@
           url (get asetukset "url")
           vanhat-koulutustoimijat (set (map :ytunnus (koulutustoimija-arkisto/hae-kaikki)))
           nyt (time/now)
-          koodit (if viimeisin-paivitys
-                   (hae-muuttuneet url viimeisin-paivitys))]
-      (log/info "Haettu kaikki organisaatiot," (count koodit) "kpl")
+          koodit (when viimeisin-paivitys (hae-muuttuneet url viimeisin-paivitys))]
       (when-not viimeisin-paivitys
         ;; Ajetaan käytännössä vain kerran. Konversiossa on tuotu organisaatioita, joita ei käytetä eikä haeta organisaatiopalvelusta
         ;; ja tällä tavalla saadaan ne merkittyä vanhentuneiksi.

--- a/aipal/src/clj/aipal/integraatio/organisaatiopalvelu.clj
+++ b/aipal/src/clj/aipal/integraatio/organisaatiopalvelu.clj
@@ -18,6 +18,7 @@
             [aipal.arkisto.toimipaikka :as toimipaikka-arkisto]
             [aipal.arkisto.organisaatiopalvelu :as organisaatiopalvelu-arkisto]
             [clj-time.core :as time]
+            [clj-time.format :as f]
             [cheshire.core :as json]
             [clj-time.coerce :as time-coerce]
             [oph.common.util.util :refer [get-json-from-url post-json-from-url map-by some-value muutos]]
@@ -40,10 +41,14 @@
 (defn hae-oidit-tyypilla [url tyyppi]
   (get-json-from-url url {:query-params {"searchTerms" (str "type=" tyyppi)}}))
 
+(def organisaatiopalvelu-formatter (f/formatter "yyyy-MM-dd hh:mm"))
+
+; Haetaan minuutin tarkkuudella niin voidaan tarvittaessa hakea useasti päivässä
 (defn hae-muuttuneet [url viimeisin-paivitys]
-  (log/info "Haetaan muuttuneet organisaatiot organisaatiopalvelusta" url)
-  (map (comp lisaa-oppilaitostyyppi halutut-kentat)
-       (get-json-from-url (str url "v4/muutetut") {:query-params {"lastModifiedSince" viimeisin-paivitys}})))
+  (let [org-aikaleima (f/unparse organisaatiopalvelu-formatter (f/parse viimeisin-paivitys))]
+    (log/info "Haetaan muuttuneet organisaatiot organisaatiopalvelusta" url "aikaleimalla" org-aikaleima)
+    (map (comp lisaa-oppilaitostyyppi halutut-kentat)
+         (get-json-from-url (str url "v4/muutetut") {:query-params {"lastModifiedSince" org-aikaleima}}))))
 
 (defn hae-era [oid-era url]
   (log/info "Haetaan erä " (count oid-era) "kpl")

--- a/aipal/src/clj/oph/common/util/util.clj
+++ b/aipal/src/clj/oph/common/util/util.clj
@@ -127,6 +127,16 @@
      cheshire/parse-string
      keywordize-keys)))
 
+(defn post-json-from-url
+  ([url]
+   (get-json-from-url url {}))
+  ([url options]
+   (->
+     (http/post url options)
+     :body
+     cheshire/parse-string
+     keywordize-keys)))
+
 (defn uusin-muokkausaika
   "Palauttaa uusimman muokkausajan annetuista arvoista.
    Polut ovat get-in-tyylisiä avainpolkuja, jotka kertovat mistä muokkausajat haetaan."


### PR DESCRIPTION
- Muuttaa toimipaikkojen päivityksen toimipistekoodista organisaatio-oidiin joka korjaa usean samalla toimipaikkakoodilla olevan toimipaikan ylikirjoittavan toisiaan.
- Kun haetaan kaikki organisaatiot
  - Haetaan vain tietyt organisaatiotyypit
  - Organisaatiot haetaan 200 erissä
- Edellä olevat nopeuttavat kaikkien organisaatioiden hakemista