### PR TITLE
CSCARVO-537: Korjaa tunnus poisto

### DIFF
--- a/aipal/src/clj/aipal/arkisto/vastaajatunnus.clj
+++ b/aipal/src/clj/aipal/arkisto/vastaajatunnus.clj
@@ -195,7 +195,7 @@
 
 (defn tunnus-poistettavissa? [kyselykertaid vastaajatunnusid]
   (let [tunnus (hae kyselykertaid vastaajatunnusid)]
-    (or false (jarjestelma-kayttajat (:luotu_kayttaja tunnus)))))
+    (not (contains? jarjestelma-kayttajat (:luotu_kayttaja tunnus)))))
 
 (defn muokkaa-lukumaaraa!
   [kyselykertaid vastaajatunnusid lukumaara]


### PR DESCRIPTION
- Korjaa vastaajatunnuksen poistamisen muilta kuin INTEGRAATIOn tai JARJESTELMAn luomilta tunnuksilta.