### PR TITLE
CSCARVO-619 kaikki oidit tarkistus

### DIFF
--- a/aipal/project.clj
+++ b/aipal/project.clj
@@ -17,7 +17,7 @@
   :dependencies [[cas-single-sign-out "0.1.3" :exclusions [clj-cas-client]]
                  [ch.qos.logback/logback-classic "1.1.5"]
                  [cheshire "5.5.0"]
-                 [clj-http "2.1.0"]
+                 [clj-http "3.10.0"]
                  [clj-time "0.11.0"]
                  [clojure-csv/clojure-csv "2.0.1"]
                  [clojurewerkz/quartzite "2.0.0"]

--- a/aipal/project.clj
+++ b/aipal/project.clj
@@ -50,7 +50,8 @@
                  [mount "0.1.11"]
                  [conman "0.6.6"]
                  [org.flatland/useful "0.11.5"]
-                 [migratus "1.0.6"]]
+                 [migratus "1.0.6"]
+                 [listora/again "1.0.0"]]
 
   :plugins [[test2junit "1.0.1"]
             [codox "0.8.12"]

--- a/aipal/src/clj/oph/common/util/cas.clj
+++ b/aipal/src/clj/oph/common/util/cas.clj
@@ -1,12 +1,17 @@
 (ns oph.common.util.cas
   (:require [clj-http.client :as http]
+            [again.core :as again]
             [clojure.tools.logging :as log]
             [aipal.asetukset :refer [asetukset]]
             [oph.common.util.util :refer [oletus-header]]
             [cheshire.core :as cheshire]))
 
+(def kirjautumistila
+  (atom {:cs (clj-http.cookies/cookie-store)
+         :tgt nil}))
+
 (defn ^:private hae-ticket-granting-url [url user password unsafe-https]
-  (let [{:keys [status headers]} (http/post (str url "/v1/tickets")
+  (let [{:keys [status headers cookies]} (http/post (str url "/v1/tickets")
                                             (oletus-header {:form-params {:username user
                                                                           :password password}
                                                             :insecure? unsafe-https}))]
@@ -22,21 +27,50 @@
       body
       (throw (RuntimeException. "Service ticketin pyytäminen CASilta epäonnistui")))))
 
-(defn request-with-cas-auth [palvelu options]
+(defmulti kirjautumisyritys ::again/status)
+(defmethod kirjautumisyritys :retry [s]
+  (log/warn "RETRY" s)
+  (log/info (:cs @kirjautumistila))
   (let [{cas-url :url
-         unsafe-https :unsafe-https
-         cas-enabled :enabled} (:cas-auth-server @asetukset)
+         unsafe-https :unsafe-https} (:cas-auth-server @asetukset)
         {palvelu-url :url
          user :user
-         password :password} (get @asetukset palvelu)]
+         password :password} (get @asetukset (-> s ::again/user-context deref :palvelu))
+        prequel-url (format "%s/cas/prequel" palvelu-url)
+        yritettyuudestaan? (-> s ::again/user-context deref :retried?)
+        _ (when (or (not (:tgt @kirjautumistila)) yritettyuudestaan?)
+            (swap! kirjautumistila assoc :tgt (hae-ticket-granting-url cas-url user password unsafe-https)))
+        ;    Tyhjennä keksit ja hae uusi ST
+        service-ticket (hae-service-ticket (:tgt @kirjautumistila) (str palvelu-url "/j_spring_cas_security_check") unsafe-https)]
+    (swap! kirjautumistila assoc :cs (clj-http.cookies/cookie-store))
+    (log/info (:cs @kirjautumistila))
+    ; Lämmittelypyyntö. Ilman tätä muut kuin get-pyynnöt epäonnistuvat (ohjaa kirjautumissivulle)
+    (http/get prequel-url (oletus-header {:query-params {"ticket" service-ticket} :cookie-store (:cs @kirjautumistila)})))
+  (swap! (::again/user-context s) assoc :retried? true))
+(defmethod kirjautumisyritys :success [s]
+  (if (-> s ::again/user-context deref :retried?)
+    (log/info "SUCCESS after" (::again/attempts s) "attempts" s)
+    (log/info "SUCCESS on first attempt" s)))
+(defmethod kirjautumisyritys :failure [s]
+  (log/error "FAILURE" s))
+
+(defn pyynto [options]
+  (let [vastaus (http/request (oletus-header (assoc options :cookie-store (:cs @kirjautumistila))))]
+    (log/info (:status vastaus))
+    (log/info (:cs @kirjautumistila))
+    (if (=(:status vastaus) 302)
+      (throw (Exception. "Poikkeus"))
+      vastaus)))
+
+(defn request-with-cas-auth [palvelu options]
+  (let [{cas-enabled :enabled} (:cas-auth-server @asetukset)]
     (if cas-enabled
-      (let [cookie-store (clj-http.cookies/cookie-store)
-            ticket-granting-url (hae-ticket-granting-url cas-url user password unsafe-https)
-            service-ticket (hae-service-ticket ticket-granting-url (str palvelu-url "/j_spring_cas_security_check") unsafe-https)
-            prequel-url (format "%s/cas/prequel" palvelu-url)]
-;        Lämmittelypyyntö. Ilman tätä muut kuin get-pyynnöt epäonnistuvat (ohjaa kirjautumissivulle)
-        (http/get prequel-url (oletus-header {:query-params {"ticket" service-ticket} :cookie-store cookie-store}))
-        (http/request (oletus-header (assoc options :cookie-store cookie-store))))
+      (again/with-retries
+       {::again/callback     kirjautumisyritys
+        ::again/strategy     [100 100]
+        ::again/user-context (atom {:palvelu palvelu})}
+;       TODO: testaa virheillä https://httpbin.org/status/500
+       (pyynto options))
       (http/request (oletus-header options)))))
 
 (defn get-with-cas-auth

--- a/aipal/src/clj/oph/common/util/cas.clj
+++ b/aipal/src/clj/oph/common/util/cas.clj
@@ -63,7 +63,7 @@
         ::again/strategy     [100 100]
         ::again/user-context (atom {:palvelu palvelu})}
         ; 302 halutaan tulkita tässä virheeksi (ohjaus kirjautumissivulle). 2xx ja 4xx hyväksytään.
-       (http/request (oletus-header (assoc options :cookie-store (:cs @kirjautumistila) :unexceptional-status #(or (<= 200 % 299) (<= 400 % 499)) ))))
+       (http/request (oletus-header (assoc options :cookie-store (:cs @kirjautumistila) :redirect-strategy :none :unexceptional-status #(or (<= 200 % 299) (<= 400 % 499)) ))))
       (http/request (oletus-header options)))))
 
 (defn get-with-cas-auth


### PR DESCRIPTION
- Lisää rajapinta henkilön kaikkien oidien hakemiseen oppijanumerorekisteristä (kyselyynohjaukselle)
- Paranna arvon cas autentikointia käyttämään sessioita ja uusimaan tarvittaessa ST ja TGT