### PR TITLE
CSCARVO-748: CAS clientin parantelua

### DIFF
--- a/aipal/src/clj/aipal/integraatio/kayttooikeuspalvelu.clj
+++ b/aipal/src/clj/aipal/integraatio/kayttooikeuspalvelu.clj
@@ -55,7 +55,6 @@
                       (map #(into {} {:rooli %
                                       :organisaatio (hae-ytunnus (:organisaatioOid organisaatio) oid->ytunnus)
                                       :voimassa true})))]
-     (log/info "Saatiin käyttäjälle" uid "oikeudet" oikeudet)
      oikeudet)))
 
 (defn kayttaja [uid ldap-ryhma->rooli oid->ytunnus]
@@ -67,6 +66,7 @@
                     flatten
                     (filter #(and (:organisaatio %) (:rooli %))))
         tiedot (when kayttaja (palvelukutsu :oppijanumerorekisteri (str oppijanumerorekisteri-url (:oidHenkilo kayttaja)) {}))]
+    (log/info "Saatiin käyttäjälle" uid "oikeudet" roolit)
     {:oid (:oidHenkilo kayttaja)
      :etunimi (or (:kutsumanimi tiedot) (:etunimet tiedot))
      :sukunimi (:sukunimi tiedot)


### PR DESCRIPTION
-Korjaa tikettien uusiminen tyhjentää keksit normaaleissa kyselyissä joka hävittää session toiseen palveluun